### PR TITLE
ci: fix sonar exclusions configuration

### DIFF
--- a/.jenkins/ci.groovy
+++ b/.jenkins/ci.groovy
@@ -7,7 +7,8 @@ node {
             enable: true,
             projectKey: "eclipse-kura_kura-bluetooth",
             tokenId: "sonarcloud-token-kura-bluetooth",
-            exclusions: "tests/**/*.java"
+            exclusions: "*.xml",
+            testExclusions: "**/*.java,*.xml"
         ],
     )
 }


### PR DESCRIPTION
This pull request makes a minor update to the SonarCloud configuration in the Jenkins CI script. The change removes the `exclusions` setting for test files, so the value relies on the default values.