### PR TITLE
ci: Added tests folder to sonar exclusions

### DIFF
--- a/.jenkins/ci.groovy
+++ b/.jenkins/ci.groovy
@@ -7,7 +7,7 @@ node {
             enable: true,
             projectKey: "eclipse-kura_kura-bluetooth",
             tokenId: "sonarcloud-token-kura-bluetooth",
-            exclusions: "**/*.xml,**/*.yml",
+            exclusions: "tests/**/*,**/*.xml,**/*.yml",
             testExclusions: "**/*"
         ],
     )


### PR DESCRIPTION
This pull request makes a minor update to the SonarCloud configuration in the CI pipeline. The change adds the `tests` directory to the list of files excluded from SonarCloud analysis.

* CI configuration: Updated the `exclusions` parameter for SonarCloud in `.jenkins/ci.groovy` to also exclude all files under the `tests` directory from analysis.