### PR TITLE
build: remove tycho-generated pom

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -85,8 +85,7 @@
                     <artifactId>tycho-packaging-plugin</artifactId>
                     <version>${tycho-version}</version>
                     <configuration>
-                        <strictVersions>true</strictVersions>
-                        <deriveHeaderFromSource>false</deriveHeaderFromSource>
+                        <skipPomGeneration>true</skipPomGeneration>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Change tycho packaging plugin to remove the wrongly generated POM that is deployed on Nexus.

<img width="1087" height="790" alt="image" src="https://github.com/user-attachments/assets/93f90e84-5251-4fb4-be02-c7d417220156" />
